### PR TITLE
refactor: use fallback blocking

### DIFF
--- a/src/pages/[slug].tsx
+++ b/src/pages/[slug].tsx
@@ -21,7 +21,7 @@ export async function getStaticPaths() {
     params: { slug }
   }))
 
-  return { paths, fallback: true }
+  return { paths, fallback: 'blocking' }
 }
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {

--- a/src/pages/place/[slug].tsx
+++ b/src/pages/place/[slug].tsx
@@ -23,7 +23,7 @@ export async function getStaticPaths() {
     params: { slug }
   }))
 
-  return { paths, fallback: true }
+  return { paths, fallback: 'blocking' }
 }
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {


### PR DESCRIPTION
Why? 

When you access https://my-trips.willianjusten.com.br/place/aaaaa for example, the server will respond with a 200 status instead of 404, them it will try to render and it will show a 404 page, but the with http status 200.