### PR TITLE
ci: fix "Only absolute URLs are supported"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - name: Create .env
+        run: echo '${{ secrets.envtesting }}' > .env
+
       - name: Install dependencies
         run: yarn install
 


### PR DESCRIPTION
That's because environment variables aren't defined, so if you create a secret (called envtesting in this PR) with the contents of your .env.local, it will work.